### PR TITLE
ci: add dependabot config for automated dependency security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,89 @@
+version: 2
+updates:
+  # Python dependencies: pyproject.toml / poetry.lock plus the exported requirements.txt
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      python-runtime:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      python-dev:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # torch/torchvision are pinned to the CUDA wheels installed in docker/Dockerfile.cuda,
+      # and the OpenCV headless builds are pinned to keep sahi working; major bumps need a
+      # coordinated change, so only take security fixes for these.
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torchvision"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "opencv-python-headless"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "opencv-contrib-python-headless"
+        update-types: ["version-update:semver-major"]
+
+  # Base images in docker/Dockerfile and docker/Dockerfile.cuda
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    ignore:
+      # Interpreter version is constrained by python = ">=3.12,<3.13" in pyproject.toml.
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # A CUDA major bump has to be matched by new torch wheels.
+      - dependency-name: "nvidia/cuda"
+        update-types: ["version-update:semver-major"]
+
+  # Workflow actions in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Hook revisions in .pre-commit-config.yaml
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so vulnerable dependencies surface as pull requests automatically. Dependabot alerts, security updates, secret scanning, and push protection have also been enabled in the repository settings (those are repo-level toggles and cannot be set from this file).

Four ecosystems are covered:

- **`pip`** (weekly) — reads `pyproject.toml`/`poetry.lock` and the pinned `requirements.txt` export. Updates are grouped (one PR for security fixes, one for production minor/patch, one for dev minor/patch) because the export pins every transitive dependency and would otherwise generate dozens of PRs per week.
- **`docker`** (weekly, `/docker`) — covers both `Dockerfile` and `Dockerfile.cuda`, since Dependabot matches any filename containing "dockerfile".
- **`github-actions`** (weekly, grouped) — the workflows currently pin `actions/checkout@v2`, `actions/checkout@v3`, and `actions/setup-python@v2`, all on end-of-life runtimes.
- **`pre-commit`** (monthly, grouped) — `pre-commit-hooks` is at `v2.3.0` and `ruff-pre-commit` at `v0.3.4`.

## Notes on the pins that are excluded from major bumps

Major-version updates are ignored for `torch`, `torchvision`, and the two OpenCV headless packages because `docker/Dockerfile.cuda` installs `torch==2.4.1 torchvision==0.19.1` from the cu121 index, so those versions are coupled to the CUDA wheel build. Likewise the `python` base image is held at 3.12 to match `python = ">=3.12,<3.13"`, and `nvidia/cuda` majors are held since they must be matched by new torch wheels. **These `ignore` rules only suppress version updates — security fixes for those packages will still open PRs.**

Commit prefixes (`build(deps)`, `ci(deps)`, `chore(deps)`) are all in the semantic-release `allowed_tags` and none are in `minor_tags`/`patch_tags`, so dependency PRs will not trigger a version bump.

## Test plan

- [x] Config is valid YAML and parses as `version: 2` with the four expected ecosystems (verified locally).
- [ ] After merge, confirm Dependabot parses the config under Insights -> Dependency graph -> Dependabot (no "config file error" banner).
- [ ] Confirm a grouped `ci(deps)` PR appears bumping the stale `actions/*` versions.

Made with [Cursor](https://cursor.com)